### PR TITLE
Device API versioning

### DIFF
--- a/config/jest/setupTestEnv.js
+++ b/config/jest/setupTestEnv.js
@@ -8,6 +8,7 @@ const enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 const url = require('url');
 const Writable = require('stream').Writable;
+const { DeviceAPIConfig } = require('../../src/main/apiConfig');
 
 enzyme.configure({ adapter: new Adapter() });
 
@@ -97,7 +98,7 @@ const jsonClient = (useHttps) => {
           method: reqMethod,
           headers: {
             'Content-Type': 'application/json',
-            'X-Device-API-Version': 1,
+            'X-Device-API-Version': DeviceAPIConfig.Version,
           },
         };
 

--- a/config/jest/setupTestEnv.js
+++ b/config/jest/setupTestEnv.js
@@ -97,6 +97,7 @@ const jsonClient = (useHttps) => {
           method: reqMethod,
           headers: {
             'Content-Type': 'application/json',
+            'X-Device-API-Version': 1,
           },
         };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6179,6 +6179,12 @@
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
         },
+        "cookiejar": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+            "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+            "dev": true
+        },
         "copy-concurrently": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -9106,6 +9112,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
             "dev": true
         },
         "fastparse": {
@@ -18302,6 +18314,98 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 }
+            }
+        },
+        "superagent": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+            "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+            "dev": true,
+            "requires": {
+                "component-emitter": "^1.3.0",
+                "cookiejar": "^2.1.2",
+                "debug": "^4.1.1",
+                "fast-safe-stringify": "^2.0.7",
+                "form-data": "^3.0.0",
+                "formidable": "^1.2.2",
+                "methods": "^1.1.2",
+                "mime": "^2.4.6",
+                "qs": "^6.9.4",
+                "readable-stream": "^3.6.0",
+                "semver": "^7.3.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "form-data": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+                    "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "formidable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+                    "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+                    "dev": true
+                },
+                "mime": {
+                    "version": "2.4.6",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+                    "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.9.4",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+                    "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                }
+            }
+        },
+        "supertest": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/supertest/-/supertest-5.0.0.tgz",
+            "integrity": "sha512-2JAWpPrUOZF4hHH5ZTCN2xjKXvJS3AEwPNXl0HUseHsfcXFvMy9kcsufIHCNAmQ5hlGCvgeAqaR5PBEouN3hlQ==",
+            "dev": true,
+            "requires": {
+                "methods": "1.1.2",
+                "superagent": "6.1.0"
             }
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "sass-loader": "^7.0.3",
         "sass-svg": "^1.0.1",
         "style-loader": "^0.21.0",
+        "supertest": "^5.0.0",
         "swagger-jsdoc": "^3.7.0",
         "url-loader": "^1.0.1",
         "webpack": "^4.44.1",

--- a/src/main/apiConfig.js
+++ b/src/main/apiConfig.js
@@ -1,6 +1,6 @@
 module.exports = {
   DeviceAPIConfig: {
-    Version: '6.0.0',
+    Version: '2', // X-Device-API-Version
     DefaultHttpPort: 61001,
     DefaultHttpsPort: 61002,
   },

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -198,7 +198,6 @@ const createBaseServer = (opts = {}) => {
   const server = restify.createServer(serverOpts);
   server.pre(restify.plugins.pre.sanitizePath());
   server.pre(restify.plugins.authorizationParser());
-  server.use(versionGatekeeper);
   server.use(restify.plugins.bodyParser());
   server.on('restifyError', handleApiError);
 
@@ -210,10 +209,11 @@ const createBaseServer = (opts = {}) => {
   // Access-Origins buys no security
   const cors = corsMiddleware({
     origins: ['*'],
-    allowHeaders: ['Authorization'],
+    allowHeaders: ['Authorization', 'X-Device-API-Version'],
   });
   server.pre(cors.preflight);
   server.use(cors.actual);
+  server.use(versionGatekeeper);
 
   return server;
 };

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -213,7 +213,7 @@ const createBaseServer = (opts = {}) => {
   });
   server.pre(cors.preflight);
   server.use(cors.actual);
-  server.use(versionGatekeeper);
+  server.use(versionGatekeeper(ApiVersion));
 
   return server;
 };

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -8,7 +8,7 @@ const { app } = require('electron');
 const { ConflictError, NotAcceptableError } = require('restify-errors');
 const { EventEmitter } = require('events');
 const { sendToGui } = require('../../guiProxy');
-
+const versionGatekeeper = require('./versionGatekeeper');
 const DeviceManager = require('../../data-managers/DeviceManager');
 const ProtocolManager = require('../../data-managers/ProtocolManager');
 const apiRequestLogger = require('../apiRequestLogger');
@@ -198,6 +198,7 @@ const createBaseServer = (opts = {}) => {
   const server = restify.createServer(serverOpts);
   server.pre(restify.plugins.pre.sanitizePath());
   server.pre(restify.plugins.authorizationParser());
+  server.use(versionGatekeeper);
   server.use(restify.plugins.bodyParser());
   server.on('restifyError', handleApiError);
 

--- a/src/main/server/devices/__tests__/DeviceAPI-test.js
+++ b/src/main/server/devices/__tests__/DeviceAPI-test.js
@@ -3,6 +3,7 @@ const EventEmitter = require('events');
 const { InvalidCredentialsError, NotAuthorizedError } = require('restify-errors');
 const request = require('supertest');
 const ProtocolManager = require('../../../data-managers/ProtocolManager');
+const { DeviceAPIConfig } = require('../../../apiConfig');
 const { DeviceAPI } = require('../DeviceAPI');
 const { jsonClient, secureClient, makeUrl, httpsCert, httpsPrivateKey } = require('../../../../../config/jest/setupTestEnv');
 const { ErrorMessages, RequestError } = require('../../../errors/RequestError');
@@ -111,8 +112,9 @@ describe('the DeviceAPI', () => {
         await request(deviceApi.server)
           .get('/devices/new')
           .expect(400, {
+            status: 'version_mismatch',
             error: 'Device API version mismatch.',
-            server: '1',
+            server: DeviceAPIConfig.Version,
             device: 'Not specified',
           });
       });
@@ -122,8 +124,9 @@ describe('the DeviceAPI', () => {
           .get('/devices/new')
           .set('X-Device-API-Version', '-999')
           .expect(400, {
+            status: 'version_mismatch',
             error: 'Device API version mismatch.',
-            server: '1',
+            server: DeviceAPIConfig.Version,
             device: '-999',
           });
       });

--- a/src/main/server/devices/__tests__/versionGatekeeper-test.js
+++ b/src/main/server/devices/__tests__/versionGatekeeper-test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+const versionGatekeeper = require('../versionGatekeeper');
+
+describe('versionGatekeeper', () => {
+  it('returns a 400 error when version mismatch', () => {
+    expect.assertions();
+    const req = { header: () => -999 };
+
+    const res = {
+      send: jest.fn(),
+    };
+
+    const next = jest.fn();
+
+    versionGatekeeper(req, res, next);
+    expect(next.mock.calls[0][0]).toBe(false);
+    expect(res.send.mock.calls[0]).toEqual([
+      400,
+      { device: -999, error: 'Device API version mismatch.', server: 1 },
+    ]);
+  });
+
+  it('calls next when version matches', () => {
+    expect.assertions(2);
+    const req = { header: () => versionGatekeeper.SERVER_API_VERSION };
+
+    const res = {
+      send: jest.fn(),
+    };
+
+    const next = jest.fn();
+
+    versionGatekeeper(req, res, next);
+    expect(res.send.mock.calls.length).toBe(0);
+    expect(next.mock.calls[0][0]).toBe(undefined);
+  });
+});

--- a/src/main/server/devices/__tests__/versionGatekeeper-test.js
+++ b/src/main/server/devices/__tests__/versionGatekeeper-test.js
@@ -4,7 +4,9 @@ const versionGatekeeper = require('../versionGatekeeper');
 describe('versionGatekeeper', () => {
   it('returns a 400 error when version mismatch', () => {
     expect.assertions();
-    const req = { header: () => -999 };
+    const serverApiVersion = '1';
+    const clientApiVersion = '-999';
+    const req = { header: () => clientApiVersion };
 
     const res = {
       send: jest.fn(),
@@ -12,17 +14,20 @@ describe('versionGatekeeper', () => {
 
     const next = jest.fn();
 
-    versionGatekeeper(req, res, next);
+    versionGatekeeper(serverApiVersion)(req, res, next);
     expect(next.mock.calls[0][0]).toBe(false);
     expect(res.send.mock.calls[0]).toEqual([
       400,
-      { device: -999, error: 'Device API version mismatch.', server: 1 },
+      { status: 'version_mismatch', device: '-999', error: 'Device API version mismatch.', server: '1' },
     ]);
   });
 
   it('calls next when version matches', () => {
     expect.assertions(2);
-    const req = { header: () => versionGatekeeper.SERVER_API_VERSION };
+    const serverApiVersion = '99';
+    const clientApiVersion = serverApiVersion;
+
+    const req = { header: () => clientApiVersion };
 
     const res = {
       send: jest.fn(),
@@ -30,7 +35,7 @@ describe('versionGatekeeper', () => {
 
     const next = jest.fn();
 
-    versionGatekeeper(req, res, next);
+    versionGatekeeper(serverApiVersion)(req, res, next);
     expect(res.send.mock.calls.length).toBe(0);
     expect(next.mock.calls[0][0]).toBe(undefined);
   });

--- a/src/main/server/devices/versionGatekeeper.js
+++ b/src/main/server/devices/versionGatekeeper.js
@@ -1,6 +1,4 @@
-const { version } = require("jszip");
-
-const SERVER_API_VERSION = 1;
+const SERVER_API_VERSION = '1';
 
 const versionGatekeeper = (req, res, next) => {
   const deviceApiVersion = req.header('X-Device-API-Version', 'Not specified');

--- a/src/main/server/devices/versionGatekeeper.js
+++ b/src/main/server/devices/versionGatekeeper.js
@@ -1,0 +1,24 @@
+const { version } = require("jszip");
+
+const SERVER_API_VERSION = 1;
+
+const versionGatekeeper = (req, res, next) => {
+  const deviceApiVersion = req.header('X-Device-API-Version', 'Not specified');
+  if (deviceApiVersion !== SERVER_API_VERSION) {
+    res.send(
+      400,
+      {
+        error: 'Device API version mismatch.',
+        server: SERVER_API_VERSION,
+        device: deviceApiVersion,
+      },
+    );
+    return next(false);
+  }
+
+  return next();
+};
+
+versionGatekeeper.SERVER_API_VERSION = SERVER_API_VERSION;
+
+module.exports = versionGatekeeper;

--- a/src/main/server/devices/versionGatekeeper.js
+++ b/src/main/server/devices/versionGatekeeper.js
@@ -1,29 +1,27 @@
 const logger = require('electron-log');
 
-const SERVER_API_VERSION = '1';
-
-const versionGatekeeper = (req, res, next) => {
-  const deviceApiVersion = req.header('X-Device-API-Version', 'Not specified');
-  if (deviceApiVersion !== SERVER_API_VERSION) {
-    logger.warn('[DeviceAPI]', {
-      error: 'X-Device-API-Version mismatch.',
-      server: SERVER_API_VERSION,
-      device: deviceApiVersion,
-    });
-    res.send(
-      400,
-      {
-        error: 'Device API version mismatch.',
+const versionGatekeeper = (SERVER_API_VERSION = '0') =>
+  (req, res, next) => {
+    const deviceApiVersion = req.header('X-Device-API-Version', 'Not specified');
+    if (deviceApiVersion !== SERVER_API_VERSION) {
+      logger.warn('[DeviceAPI]', {
+        error: 'X-Device-API-Version mismatch.',
         server: SERVER_API_VERSION,
         device: deviceApiVersion,
-      },
-    );
-    return next(false);
-  }
+      });
+      res.send(
+        400,
+        {
+          status: 'version_mismatch',
+          error: 'Device API version mismatch.',
+          server: SERVER_API_VERSION,
+          device: deviceApiVersion,
+        },
+      );
+      return next(false);
+    }
 
-  return next();
-};
-
-versionGatekeeper.SERVER_API_VERSION = SERVER_API_VERSION;
+    return next();
+  };
 
 module.exports = versionGatekeeper;

--- a/src/main/server/devices/versionGatekeeper.js
+++ b/src/main/server/devices/versionGatekeeper.js
@@ -1,4 +1,5 @@
 const logger = require('electron-log');
+
 const SERVER_API_VERSION = '1';
 
 const versionGatekeeper = (req, res, next) => {

--- a/src/main/server/devices/versionGatekeeper.js
+++ b/src/main/server/devices/versionGatekeeper.js
@@ -1,8 +1,14 @@
+const logger = require('electron-log');
 const SERVER_API_VERSION = '1';
 
 const versionGatekeeper = (req, res, next) => {
   const deviceApiVersion = req.header('X-Device-API-Version', 'Not specified');
   if (deviceApiVersion !== SERVER_API_VERSION) {
+    logger.warn('[DeviceAPI]', {
+      error: 'X-Device-API-Version mismatch.',
+      server: SERVER_API_VERSION,
+      device: deviceApiVersion,
+    });
     res.send(
       400,
       {


### PR DESCRIPTION
Add required header to device api: `X-Device-API-Version`.

If version matches server respond as normal, if version mismatch or no header supplied return a `400` error and a json error in the format:

```
{
  error: 'Device API version mismatch.',
  server: '[Server api version number]'
  device: '[Supplied api version number]'
}
```

Resolves https://github.com/complexdatacollective/Server/issues/294