### PR TITLE
Fix snap package

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,17 +180,9 @@
           ]
         },
         {
-          "target": "rpm",
-          "arch": [
-            "x64",
-            "arm64"
-          ]
-        },
-        {
           "target": "snap",
           "arch": [
-            "x64",
-            "arm64"
+            "x64"
           ]
         }
       ]


### PR DESCRIPTION
- Updates network-exporter to use copy rather than rename
- Update package.json to include snap build

Requires: https://github.com/complexdatacollective/network-exporters/pull/26