### PR TITLE
use codebook option values for categorical variables

### DIFF
--- a/src/main/MainApp.js
+++ b/src/main/MainApp.js
@@ -70,6 +70,8 @@ const createApp = () => {
     dialog.showErrorBox('Session Import Error', err && err.message);
   });
 
+  const correctSessionVariableTypes = () => protocolManager.correctSessionVariableTypes();
+
   const generateTestSessions = (number) => {
     protocolManager.allProtocols().then((allProtocols) => {
       const developmentProtocol = find(allProtocols, ['name', 'Development']);
@@ -145,15 +147,20 @@ const createApp = () => {
         { role: 'toggledevtools' },
         { type: 'separator' },
         {
-          label: 'Generate large test dataset...',
+          label: 'Correct Inconsistent Variable Types',
+          click: correctSessionVariableTypes,
+        },
+        { type: 'separator' },
+        {
+          label: 'Generate large test dataset',
           click: () => generateTestSessions(4500),
         },
         {
-          label: 'Generate small test dataset...',
+          label: 'Generate small test dataset',
           click: () => generateTestSessions(100),
         },
         {
-          label: 'Generate tiny test dataset...',
+          label: 'Generate tiny test dataset',
           click: () => generateTestSessions(3),
         },
         { type: 'separator' },

--- a/src/main/data-managers/SessionDB.js
+++ b/src/main/data-managers/SessionDB.js
@@ -1,4 +1,5 @@
 /* eslint no-underscore-dangle: ["error", { "allow": ["_id"] }] */
+const { get } = require('lodash');
 const DatabaseAdapter = require('./DatabaseAdapter');
 const Reportable = require('./Reportable');
 const { ErrorMessages, RequestError } = require('../errors/RequestError');
@@ -81,6 +82,21 @@ class SessionDB extends Reportable(DatabaseAdapter) {
   find(query) {
     return new Promise((resolve, reject) => {
       this.db.find(query, { multi: true }, resolveOrReject(resolve, reject));
+    });
+  }
+
+  /**
+   * Update session associated with a protocol
+   */
+  update(protocolId, session) {
+    if (!protocolId) {
+      return Promise.reject(new Error(`Invalid protocol ID (${protocolId})`));
+    }
+    const query = { protocolId };
+    query._id = get(session, '_id');
+
+    return new Promise((resolve, reject) => {
+      this.db.update(query, session, { multi: true }, resolveOrReject(resolve, reject));
     });
   }
 

--- a/src/main/data-managers/__tests__/SessionDB-test.js
+++ b/src/main/data-managers/__tests__/SessionDB-test.js
@@ -79,6 +79,14 @@ describe('SessionDB', () => {
     expect(found).toHaveLength(0);
   });
 
+  it('updates sessions', async () => {
+    await sessions.insertAllForProtocol(mockSession, mockProtocol);
+    const found = await sessions.find({ protocolId: mockProtocol._id, _id: mockSession.uuid });
+    await sessions.update(mockProtocol._id, { ...found[0], data: { something: 'new' } });
+    const result = await sessions.find({ protocolId: mockProtocol._id, _id: mockSession.uuid });
+    expect(result[0]).toMatchObject({ data: { something: 'new' } });
+  });
+
   it('requires IDs on sessions', async () => {
     jest.spyOn(sessions.db, 'insert');
     const promise = sessions.insertAllForProtocol([{}], mockProtocol);

--- a/src/main/utils/importGraphML.js
+++ b/src/main/utils/importGraphML.js
@@ -125,7 +125,9 @@ const processVariable = (element, entity, xmlDoc, codebookEntity, entityType = '
     // fallback to using whatever is after the first underscore
     const optionValue = optionIndex > 0 ? catValue.substring(optionIndex) : catValue.substring(catValue.indexOf('_') + 1);
     // lookup in codebook the option's values (because numbers could be strings here)
-    const codebookOption = codebookOptions.find(option => option.value.toString() === optionValue);
+    const codebookOption = codebookOptions.find(
+      (option) => option.value.toString() === optionValue,
+    );
     // fallback to graphml value if not matched in codebook
     const codebookOptionValue = (codebookOption && codebookOption.value) || optionValue;
     catVar.push(codebookOptionValue);

--- a/src/main/utils/importGraphML.js
+++ b/src/main/utils/importGraphML.js
@@ -1,6 +1,6 @@
 const dom = require('xmldom');
 const {
-  get, map, reduce, difference, isArray,
+  get, map, reduce, difference, isArray, isNil,
 } = require('lodash');
 const { ErrorMessages, RequestError } = require('../errors/RequestError');
 const {
@@ -132,7 +132,8 @@ const processVariable = (element, entity, xmlDoc, codebookEntity, entityType = '
       (option) => option.value.toString() === optionValue,
     );
     // fallback to graphml value if not matched in codebook
-    const codebookOptionValue = (codebookOption && codebookOption.value) || optionValue;
+    const codebookOptionValue = (codebookOption
+      && !isNil(codebookOption.value)) ? codebookOption.value : optionValue;
     catVar.push(codebookOptionValue);
     return { ...entity, attributes: { ...entity.attributes, [catKey]: catVar } };
   }
@@ -230,7 +231,8 @@ const getCorrectEntityVariableType = (entity, codebookEntity, entityType) => {
           const codebookOption = options.find(
             (option) => option.value.toString() === value,
           );
-          const codebookOptionValue = (codebookOption && codebookOption.value) || value;
+          const codebookOptionValue = (codebookOption
+            && !isNil(codebookOption.value)) ? codebookOption.value : value;
           return codebookOptionValue;
         })) : attributeValue;
 

--- a/src/main/utils/importGraphML.js
+++ b/src/main/utils/importGraphML.js
@@ -119,11 +119,16 @@ const processVariable = (element, entity, xmlDoc, codebookEntity, entityType = '
     const catKey = keyValue.substring(0, keyValue.indexOf('_'));
     const catVar = (entity.attributes && entity.attributes[catKey]) || []; // previous options
     const codebookVarName = codebookEntity.variables[catKey].name;
+    const codebookOptions = codebookEntity.variables[catKey].options || [];
     const catValue = xmlDoc.getElementById(keyValue).getAttributeNode('attr.name').value; // variable_option
     const optionIndex = codebookVarName.length + 1; // add one for the underscore
-    // fallback to using whatever it after the first underscore
-    const codebookOptionName = optionIndex > 0 ? catValue.substring(optionIndex) : catValue.substring(catValue.indexOf('_') + 1);
-    catVar.push(codebookOptionName);
+    // fallback to using whatever is after the first underscore
+    const optionValue = optionIndex > 0 ? catValue.substring(optionIndex) : catValue.substring(catValue.indexOf('_') + 1);
+    // lookup in codebook the option's values (because numbers could be strings here)
+    const codebookOption = codebookOptions.find(option => option.value.toString() === optionValue);
+    // fallback to graphml value if not matched in codebook
+    const codebookOptionValue = (codebookOption && codebookOption.value) || optionValue;
+    catVar.push(codebookOptionValue);
     return { ...entity, attributes: { ...entity.attributes, [catKey]: catVar } };
   }
   return entity;

--- a/src/renderer/containers/workspace/withAnswerDistributionCharts.js
+++ b/src/renderer/containers/workspace/withAnswerDistributionCharts.js
@@ -46,7 +46,7 @@ const shapeBucketDataByType = (
       const isOptionObject = option && typeof option === 'object';
       // - label is optional, in which case `value` is used as the label
       const name = isOptionObject ? (option.label || option.value) : option;
-      const dataKey = (isOptionObject ? option.value : option).toString();
+      const dataKey = (isOptionObject ? option.value : option);
       return {
         name,
         value: data[dataKey] || 0,


### PR DESCRIPTION
Fixes #336.

The issue here turned out to be on the import side of the pipeline. We use graphml `attr.type` to determine how to process values, whether they need to be cast as numbers or something. But categorical variables are of type `boolean` in graphml because we format them as `variableName_optionValue`. When we parse the underscores to pull out the `optionValue`, we then were left with a string. This is fine, except when option values are numerical. (e.g. a variable named `ind_K6a_3` would have a value of "3" when it should be `3`)

In this fix, I opted to leverage the codebook and lean on the codebook option value so that we have type correct, since the codebook is the definitive source.

The secondary mystery here is that charts seemed fully functional either way. It turns out we've been casting option values as strings all along:

https://github.com/complexdatacollective/Server/blob/master/src/renderer/containers/workspace/withAnswerDistributionCharts.js#L49

So do we fix this and not cast them, or leave it because it's not harming anything? Removing the `toString` here makes the charts correct, but if it isn't harming anything, then are users currently seeing what they expect? Or would fixing this alert them that they need to re-import some graphmls?