### PR TITLE
bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-server-6",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
@@ -43772,7 +43772,10 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/react-identicons/-/react-identicons-1.2.4.tgz",
             "integrity": "sha512-my4CFMlO88kWjhX/y5qiGjQE9KgVLLeUKEM2wilUko6UzUTmzHJvl0rjkcftG9bMq3WLkpJkB2qwFMRllS+NmQ==",
-            "requires": {}
+            "requires": {
+                "react": "^16.13.0",
+                "react-dom": "^16.13.0"
+            }
         },
         "react-is": {
             "version": "16.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,14 @@
     "packages": {
         "": {
             "name": "network-canvas-server-6",
-            "version": "6.1.0",
+            "version": "6.1.1",
             "dependencies": {
                 "@babel/runtime": "^7.11.2",
                 "animejs": "^2.2.0",
                 "archiver": "^4.0.1",
                 "async": "^3.2.0",
                 "big-integer": "^1.6.43",
+                "caniuse-lite": "^1.0.30001302",
                 "classnames": "^2.2.6",
                 "compare-versions": "^3.6.0",
                 "detect-port": "^1.2.3",
@@ -6102,10 +6103,13 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001204",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-            "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
-            "dev": true
+            "version": "1.0.30001302",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
+            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/browserslist"
+            }
         },
         "node_modules/capture-exit": {
             "version": "2.0.0",
@@ -32620,10 +32624,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001204",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-            "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
-            "dev": true
+            "version": "1.0.30001302",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
+            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw=="
         },
         "capture-exit": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
         "archiver": "^4.0.1",
         "async": "^3.2.0",
         "big-integer": "^1.6.43",
+        "caniuse-lite": "^1.0.30001302",
         "classnames": "^2.2.6",
         "compare-versions": "^3.6.0",
         "detect-port": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-server-6",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "productName": "Network Canvas Server",
     "description": "A tool for storing, analyzing, and exporting Network Canvas interview data.",
     "private": true,

--- a/src/main/MainApp.js
+++ b/src/main/MainApp.js
@@ -70,7 +70,18 @@ const createApp = () => {
     dialog.showErrorBox('Session Import Error', err && err.message);
   });
 
-  const correctSessionVariableTypes = () => protocolManager.correctSessionVariableTypes();
+  const correctSessionVariableTypes = () => dialog.showMessageBox(mainWindow.window, {
+    type: 'warning',
+    title: 'Correcting variable types',
+    message: 'This action will attempt to correct issues with sessions imported from graphml files that contain categorical data. If this scenario does not apply to you, click cancel. Please export or backup your data prior to proceeding as this process could result in data loss.',
+    buttons: ['Cancel', 'Continue'],
+    cancelId: 0,
+    defaultId: 0,
+  }).then(({ response }) => {
+    if (response === 1) {
+      protocolManager.correctSessionVariableTypes();
+    }
+  });
 
   const generateTestSessions = (number) => {
     protocolManager.allProtocols().then((allProtocols) => {

--- a/src/main/data-managers/ProtocolManager.js
+++ b/src/main/data-managers/ProtocolManager.js
@@ -679,8 +679,10 @@ class ProtocolManager {
       }).catch((err) => Promise.reject(constructErrorObject(err.message, caseId)));
   }
 
-  correctSessionVariableTypes() {
-    this.allProtocols().then((allProtocols) => {
+  async correctSessionVariableTypes() {
+    let changesMade = false;
+
+    await this.allProtocols().then((allProtocols) => {
       allProtocols.forEach((protocol) => {
         const protocolId = get(protocol, '_id');
         this.getProtocolSessions(protocolId)
@@ -696,7 +698,8 @@ class ProtocolManager {
                   const ego = getCorrectEntityVariableTypes(sessionData.data.ego, protocol.codebook, 'ego');
 
                   if (nodes.altered || edges.altered || ego.altered) {
-                    logger.log(`CORRECTING SESSION ${sessionId} FROM INVALID CATEGORICAL OPTIONS`);
+                    changesMade = true;
+                    logger.log(`CORRECTING INVALID CATEGORICAL OPTIONS FOUND IN SESSION ${sessionId} `);
                     const updatedSession = {
                       ...sessionData,
                       data: {
@@ -715,6 +718,22 @@ class ProtocolManager {
           });
       });
     });
+
+    if (changesMade) {
+      dialog.showMessageBox(null, {
+        type: 'info',
+        title: 'Session Variable Type Correction',
+        message: 'Some session variables had invalid options. These have been corrected.',
+        buttons: ['OK'],
+      });
+    } else {
+      dialog.showMessageBox(null, {
+        type: 'info',
+        title: 'Session Variable Type Correction',
+        message: 'No session variables had invalid options. No changes were made to your data.',
+        buttons: ['OK'],
+      });
+    }
   }
 
   /**

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-server-6",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "productName": "Network Canvas Server",
     "description": "A tool for storing, analyzing, and exporting Network Canvas interview data.",
     "private": true,

--- a/src/renderer/containers/EntityResolverScreen/NewResolution.js
+++ b/src/renderer/containers/EntityResolverScreen/NewResolution.js
@@ -9,6 +9,7 @@ import Tip from '../../components/Tip';
 import BrowseInput from '../../components/BrowseInput';
 import withValidation from './withValidation';
 import { getNodeTypes } from './selectors';
+import { ExternalLink } from '../../components/ExternalLink';
 
 const ValidatedBrowseInput = withValidation(BrowseInput);
 
@@ -114,10 +115,9 @@ const NewResolution = ({
                     This should be the path of your custom resolver script. Please
                     read the documentation for more information on
                     {' '}
-                    <a href="">
-                      how
-                      to create a resolver script
-                    </a>
+                    <ExternalLink href="https://github.com/complexdatacollective/entity-resolution-sample">
+                      how to create a resolver script
+                    </ExternalLink>
                     .
                   </p>
                   <ValidatedBrowseInput


### PR DESCRIPTION
## Network Canvas Server 6.1.1

This is a bugfix release, and should be installed by all users currently running version 6.1.0. It fixes an issue related to sessions imported via graphml that contain categorical values.

If you are impacted by this issue, a special menu command (Develop -> Correct inconsistent variable types) has been implemented that you can use to automatically fix the issue.

### Changelog:

- Fixes an issue whereby sessions that were imported to Server from graphml files would not correctly export their categorical variables